### PR TITLE
Add subscription flow and profile pages with Firebase placeholders

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,33 @@
+// Firebase configuration - replace with your project's details
+const firebaseConfig = {
+  apiKey: "YOUR_FIREBASE_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+
+// Initialize Firebase
+firebase.initializeApp(firebaseConfig);
+const auth = firebase.auth();
+const db = firebase.firestore();
+
+// Example user document structure
+// users/{uid} {
+//   email: string,
+//   role: 'Warrior' | 'Ambassador' | 'Resident' | 'Admin',
+//   carbonCoins: number,
+//   subscriptionStartDate: Timestamp,
+//   membershipDetails: {
+//     type: string,
+//     amount: number,
+//     currency: string,
+//     utr?: string
+//   },
+//   access: {
+//     coWorkPondi: boolean,
+//     productDiscount: boolean,
+//     priorityEvents: boolean
+//   }
+// }

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
         Collaborative | Experimental | Innovative<br>
         Self-Sustainable | Holistic
       </p>
-      <button onclick="window.location.href='https://chat.whatsapp.com/LUlrfRH2c17A2PmHAUaajl'" class="bg-green-600 text-white px-8 py-3 rounded-full hover:bg-green-700 transition">
+      <button onclick="window.location.href='subscribe.html'" class="bg-green-600 text-white px-8 py-3 rounded-full hover:bg-green-700 transition">
         Join the Movement
       </button>
     </div>

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Your Profile - Erthaloka</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="firebase.js"></script>
+</head>
+<body class="bg-black text-white font-sans">
+  <div class="container mx-auto px-4 py-12">
+    <h1 class="text-3xl font-bold mb-6">Profile</h1>
+    <p>Email: <span id="email"></span></p>
+    <p>Membership Tier: <span id="tier"></span></p>
+    <p>Subscription Start: <span id="start"></span></p>
+    <h2 class="text-2xl font-semibold mt-6 mb-2">Access</h2>
+    <ul id="accessList" class="list-disc pl-6"></ul>
+  </div>
+  <script>
+    firebase.auth().onAuthStateChanged(user => {
+      if(!user){
+        window.location.href = 'signin.html';
+        return;
+      }
+      document.getElementById('email').textContent = user.email;
+      firebase.firestore().collection('users').doc(user.uid).get().then(doc => {
+        const data = doc.data() || {};
+        document.getElementById('tier').textContent = data.role || 'Warrior';
+        document.getElementById('start').textContent = data.subscriptionStartDate ? data.subscriptionStartDate.toDate().toDateString() : 'N/A';
+        const access = data.access || {};
+        const list = document.getElementById('accessList');
+        list.innerHTML = '';
+        Object.entries(access).forEach(([k,v])=>{
+          const li = document.createElement('li');
+          li.textContent = `${k}: ${v ? 'Yes' : 'No'}`;
+          list.appendChild(li);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/signin.html
+++ b/signin.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign In - Erthaloka</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+  <script src="firebase.js"></script>
+</head>
+<body class="bg-black text-white font-sans flex items-center justify-center h-screen">
+  <div class="bg-gray-800 p-8 rounded-xl shadow-lg border border-gray-700 max-w-sm w-full">
+    <h1 class="text-2xl font-bold mb-4">Sign In</h1>
+    <input id="email" type="email" placeholder="Email" class="w-full p-2 mb-2 text-black">
+    <input id="password" type="password" placeholder="Password" class="w-full p-2 mb-4 text-black">
+    <button id="signInBtn" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-full mb-2">Sign In</button>
+    <button id="googleBtn" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded w-full">Google Sign-In</button>
+  </div>
+  <script>
+    document.getElementById('signInBtn').addEventListener('click', () => {
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+      firebase.auth().signInWithEmailAndPassword(email, password).then(() => {
+        window.location.href = 'profile.html';
+      }).catch(err => alert(err.message));
+    });
+    document.getElementById('googleBtn').addEventListener('click', () => {
+      const provider = new firebase.auth.GoogleAuthProvider();
+      firebase.auth().signInWithPopup(provider).then(() => {
+        window.location.href = 'profile.html';
+      }).catch(err => alert(err.message));
+    });
+  </script>
+</body>
+</html>

--- a/subscribe.html
+++ b/subscribe.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Subscribe - Erthaloka</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/framer-motion/10.12.16/framer-motion.umd.min.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <script src="firebase.js"></script>
+</head>
+<body class="bg-black text-white font-sans">
+  <div class="container mx-auto px-4 py-12">
+    <h1 class="text-3xl font-bold text-center mb-8">Choose Your Plan</h1>
+    <div class="grid md:grid-cols-3 gap-8" id="planGrid">
+      <!-- Plan cards inserted by JS -->
+    </div>
+    <div id="paymentStep" class="hidden mt-10">
+      <h2 class="text-xl font-semibold mb-4">Choose Payment Method</h2>
+      <div class="flex flex-col gap-6">
+        <button id="payRazorpay" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-48">Pay with Razorpay</button>
+        <div class="bg-gray-800 p-6 rounded-xl shadow-lg border border-gray-700 max-w-md">
+          <h3 class="text-lg font-semibold mb-2">Free UPI</h3>
+          <p class="mb-2">Pay <span id="upiAmount"></span> to UPI ID <strong>erthaloka@upi</strong></p>
+          <img src="assets/images/upi_qr.png" alt="UPI QR" class="w-40 mb-2">
+          <input type="text" id="utrInput" placeholder="Enter UPI Transaction ID" class="w-full p-2 text-black mb-2">
+          <button id="submitUtr" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-full">Submit UTR for Verification</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="subscribe.js"></script>
+</body>
+</html>

--- a/subscribe.js
+++ b/subscribe.js
@@ -1,0 +1,121 @@
+const plans = {
+  resident: {
+    type: 'Resident',
+    amount: 9999,
+    currency: 'INR',
+    perks: [
+      'Residency starting @ 9999/- per month',
+      'Get access to our community co-work spaces @ Pondi & Auroville',
+      'Get Access to Erthaloka Community & Network',
+      'Get 10% Discount on Products & Services',
+      'Priority Access to Events'
+    ]
+  },
+  ambassador: {
+    type: 'Ambassador',
+    amount: 3333,
+    currency: 'INR',
+    perks: [
+      'Ambassador @ 3333/- per month',
+      'Get access to our community co-work spaces @ Pondi & Auroville',
+      'Get Access to Erthaloka Community & Network',
+      'Get 10% Discount on Products & Services',
+      'Priority Access to Events'
+    ]
+  },
+  warrior: {
+    type: 'Warrior',
+    amount: 0,
+    currency: 'INR',
+    perks: [
+      'Warrior - Free Sign-up',
+      'Get access to our community co-work spaces @ 99/- per day',
+      'Get 10% Discount on Products & Services'
+    ]
+  }
+};
+
+let selectedPlan = null;
+
+function createPlanCard(key, plan) {
+  const card = document.createElement('div');
+  card.className = 'bg-gray-800 p-6 rounded-xl shadow-lg border border-gray-700 flex flex-col';
+  const title = document.createElement('h3');
+  title.className = 'text-xl font-bold mb-4';
+  title.textContent = plan.type;
+  card.appendChild(title);
+  const list = document.createElement('ul');
+  list.className = 'mb-6 flex-1 list-disc pl-6';
+  plan.perks.forEach(p => {
+    const li = document.createElement('li');
+    li.textContent = p;
+    list.appendChild(li);
+  });
+  card.appendChild(list);
+  const btn = document.createElement('button');
+  btn.className = 'bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded';
+  btn.textContent = 'Select Plan';
+  btn.addEventListener('click', () => selectPlan(key));
+  card.appendChild(btn);
+  return card;
+}
+
+function renderPlans() {
+  const grid = document.getElementById('planGrid');
+  Object.entries(plans).forEach(([key, plan]) => {
+    grid.appendChild(createPlanCard(key, plan));
+  });
+}
+
+function selectPlan(key) {
+  selectedPlan = plans[key];
+  document.getElementById('paymentStep').classList.remove('hidden');
+  document.getElementById('upiAmount').textContent = `${selectedPlan.amount} ${selectedPlan.currency}`;
+}
+
+document.getElementById('payRazorpay').addEventListener('click', async () => {
+  if (!selectedPlan) return;
+  const script = document.createElement('script');
+  script.src = 'https://checkout.razorpay.com/v1/checkout.js';
+  document.body.appendChild(script);
+  script.onload = () => initiateRazorpay();
+});
+
+function initiateRazorpay() {
+  // In practice, create the order on your server or Cloud Function
+  // This is a placeholder example
+  const options = {
+    key: 'RAZORPAY_KEY_ID',
+    amount: selectedPlan.amount * 100,
+    currency: selectedPlan.currency,
+    name: 'Erthaloka',
+    description: selectedPlan.type,
+    handler: function (response){
+      // Verify payment on the server then update Firestore
+      console.log('Payment success', response);
+    }
+  };
+  const rzp = new Razorpay(options);
+  rzp.open();
+}
+
+document.getElementById('submitUtr').addEventListener('click', () => {
+  const utr = document.getElementById('utrInput').value.trim();
+  if (!utr || !selectedPlan) return;
+  // Save UTR for manual verification in Firestore
+  const user = firebase.auth().currentUser;
+  if (!user) return alert('Please sign in');
+  firebase.firestore().collection('users').doc(user.uid).set({
+    membershipDetails: {
+      type: selectedPlan.type,
+      amount: selectedPlan.amount,
+      currency: selectedPlan.currency,
+      utr
+    },
+    subscriptionStartDate: firebase.firestore.FieldValue.serverTimestamp()
+  }, { merge: true }).then(() => {
+    alert('UTR submitted. Your plan will be activated after verification.');
+  });
+});
+
+renderPlans();


### PR DESCRIPTION
## Summary
- update CTA on landing page to point to new `subscribe.html`
- add `firebase.js` with configuration and user document example
- create subscription selection page with Razorpay and manual UPI options
- add profile page showing membership info from Firestore
- add simple email/password & Google sign in page
- include JS logic for plan selection and payment handling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684862b511088320b819323e64e9bb03