### PR TITLE
Add Firebase auth and subscription pages

### DIFF
--- a/erthaloka-next/package.json
+++ b/erthaloka-next/package.json
@@ -14,7 +14,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0"
+    "firebase": "^11.9.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/erthaloka-next/src/app/(auth)/signin/page.tsx
+++ b/erthaloka-next/src/app/(auth)/signin/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { useState } from 'react';
+import { signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import { auth } from '../../firebase/config';
+import Link from 'next/link';
+
+export default function SignIn() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const handleGoogle = async () => {
+    try {
+      await signInWithPopup(auth, new GoogleAuthProvider());
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="p-8 bg-gray-800 rounded-lg shadow-xl bg-opacity-90">
+        <h1 className="text-2xl mb-4 text-center">Sign In</h1>
+        <div className="mb-4">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full p-2 rounded bg-gray-700 border border-gray-600 focus:border-green-500 focus:outline-none"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full p-2 rounded bg-gray-700 border border-gray-600 focus:border-green-500 focus:outline-none"
+            required
+          />
+        </div>
+        {error && <p className="text-red-500 mb-2">{error}</p>}
+        <button type="submit" className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded mb-2">
+          Sign In
+        </button>
+        <button type="button" onClick={handleGoogle} className="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded">
+          Sign in with Google
+        </button>
+        <p className="text-center mt-4 text-sm">
+          Don't have an account? <Link className="text-blue-400" href="/signup">Sign up</Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/erthaloka-next/src/app/(auth)/signup/page.tsx
+++ b/erthaloka-next/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { useState } from 'react';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../../firebase/config';
+import Link from 'next/link';
+
+export default function SignUp() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <form onSubmit={handleSubmit} className="p-8 bg-gray-800 rounded-lg shadow-xl bg-opacity-90">
+        <h1 className="text-2xl mb-4 text-center">Sign Up</h1>
+        <div className="mb-4">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full p-2 rounded bg-gray-700 border border-gray-600 focus:border-green-500 focus:outline-none"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full p-2 rounded bg-gray-700 border border-gray-600 focus:border-green-500 focus:outline-none"
+            required
+          />
+        </div>
+        {error && <p className="text-red-500 mb-2">{error}</p>}
+        <button type="submit" className="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded">
+          Sign Up
+        </button>
+        <p className="text-center mt-4 text-sm">
+          Already have an account? <Link className="text-blue-400" href="/signin">Sign in</Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/erthaloka-next/src/app/layout.tsx
+++ b/erthaloka-next/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "@fontsource/inter/400.css";
 import "@fontsource/inter/700.css";
 import "./globals.css";
+import { AuthProvider } from "../context/AuthContext";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,7 +16,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="font-sans antialiased">{children}</body>
+      <body className="font-sans antialiased">
+        <AuthProvider>{children}</AuthProvider>
+      </body>
     </html>
   );
 }

--- a/erthaloka-next/src/app/profile/page.tsx
+++ b/erthaloka-next/src/app/profile/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useAuth } from '@/context/AuthContext';
+import { useEffect, useState } from 'react';
+import { doc, getFirestore, onSnapshot } from 'firebase/firestore';
+
+export default function Profile() {
+  const { user } = useAuth();
+  const [coins, setCoins] = useState(0);
+
+  useEffect(() => {
+    if (!user) return;
+    const db = getFirestore();
+    const unsub = onSnapshot(doc(db, 'users', user.uid), snap => {
+      setCoins(snap.exists() ? snap.data().carbonCoins || 0 : 0);
+    });
+    return unsub;
+  }, [user]);
+
+  if (!user) {
+    return <div className="min-h-screen flex items-center justify-center">Please sign in to view your profile.</div>;
+  }
+
+  return (
+    <section className="max-w-3xl mx-auto py-20 space-y-6">
+      <h1 className="text-4xl font-bold text-center mb-4">Profile</h1>
+      <div className="bg-gray-800 rounded-xl shadow-xl p-6">
+        <p><strong>Email:</strong> {user.email}</p>
+        <p><strong>Carbon Coins:</strong> {coins}</p>
+      </div>
+    </section>
+  );
+}

--- a/erthaloka-next/src/app/subscribe/page.tsx
+++ b/erthaloka-next/src/app/subscribe/page.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+export default function Subscribe() {
+  return (
+    <section className="max-w-6xl mx-auto space-y-8 py-20">
+      <h1 className="text-4xl md:text-5xl font-bold text-center text-accent-green mb-8">Choose Your Plan</h1>
+      <div className="grid md:grid-cols-3 gap-8">
+        <div className="bg-gray-800 p-6 rounded-xl shadow-lg border border-purple-500 flex flex-col items-center">
+          <h2 className="text-2xl font-semibold mb-4">Warrior</h2>
+          <p className="mb-2 text-center">Free Sign-up</p>
+          <p className="mb-6 text-center">Access co-work spaces @ 99/- per day</p>
+          <button className="rounded-full bg-purple-600 px-6 py-2 hover:scale-105 transition-transform">Select Plan</button>
+        </div>
+        <div className="bg-gray-800 p-6 rounded-xl shadow-lg border border-blue-500 flex flex-col items-center">
+          <h2 className="text-2xl font-semibold mb-4">Ambassador</h2>
+          <p className="mb-2 text-center">3333/- per month</p>
+          <p className="mb-6 text-center">Full access to community spaces</p>
+          <button className="rounded-full bg-blue-600 px-6 py-2 hover:scale-105 transition-transform">Select Plan</button>
+        </div>
+        <div className="bg-gray-800 p-6 rounded-xl shadow-lg border border-green-500 flex flex-col items-center">
+          <h2 className="text-2xl font-semibold mb-4">Resident</h2>
+          <p className="mb-2 text-center">9999/- per month</p>
+          <p className="mb-6 text-center">Priority access to all events</p>
+          <button className="rounded-full bg-green-600 px-6 py-2 hover:scale-105 transition-transform">Select Plan</button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/erthaloka-next/src/components/EcoVerseModel.tsx
+++ b/erthaloka-next/src/components/EcoVerseModel.tsx
@@ -1,24 +1,56 @@
 'use client';
 import { motion } from 'framer-motion';
-import { FaHandsHelping, FaRecycle, FaHeart } from 'react-icons/fa';
+const HandsIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-14 h-14"
+  >
+    <path d="M12 12c-2.21 0-4-1.79-4-4V4h2v4c0 1.1.9 2 2 2s2-.9 2-2V4h2v4c0 2.21-1.79 4-4 4z" />
+    <path d="M6 12v4c0 3.31 2.69 6 6 6s6-2.69 6-6v-4h-2v4c0 2.21-1.79 4-4 4s-4-1.79-4-4v-4H6z" />
+  </svg>
+);
+
+const RecycleIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-14 h-14"
+  >
+    <path d="M12 4l1.41 1.41L10.83 8H13v2H8V5h2v2.17l2.59-2.58zM8 12l-1.41-1.41L11.17 6H9V4h5v5h-2V6.83l-4.59 4.58zm8 0l1.41 1.41L12.83 18H15v2h-5v-5h2v2.17l4.59-4.58z" />
+  </svg>
+);
+
+const HeartIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-14 h-14"
+  >
+    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+  </svg>
+);
 
 const cards = [
   {
     title: 'People',
     color: 'text-accent-green',
-    icon: <FaHandsHelping className="text-6xl" />,
+    icon: HandsIcon,
     text: 'Empowering communities with knowledge and resources.',
   },
   {
     title: 'Planet',
     color: 'text-accent-blue',
-    icon: <FaRecycle className="text-6xl" />,
+    icon: RecycleIcon,
     text: 'Sustainable practices to regenerate our environment.',
   },
   {
     title: 'Purpose',
     color: 'text-accent-purple',
-    icon: <FaHeart className="text-6xl" />,
+    icon: HeartIcon,
     text: 'Aligning efforts towards a shared regenerative future.',
   },
 ];

--- a/erthaloka-next/src/components/Footer.tsx
+++ b/erthaloka-next/src/components/Footer.tsx
@@ -1,14 +1,45 @@
 'use client';
-import { FaFacebook, FaTwitter, FaInstagram } from 'react-icons/fa';
+const FacebookIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6"
+  >
+    <path d="M22 12c0-5.52-4.48-10-10-10S2 6.48 2 12c0 5 3.66 9.13 8.44 9.88v-6.99H7.9v-2.89h2.54V9.41c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.45h-1.26c-1.24 0-1.63.77-1.63 1.56v1.87h2.78l-.44 2.89h-2.34v6.99C18.34 21.13 22 17 22 12z" />
+  </svg>
+);
+
+const TwitterIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6"
+  >
+    <path d="M22.46 6c-.77.35-1.6.59-2.46.7a4.25 4.25 0 001.88-2.34 8.41 8.41 0 01-2.69 1.03A4.21 4.21 0 0015.5 4a4.21 4.21 0 00-4.2 4.2c0 .33.04.65.11.96A11.94 11.94 0 013 5.11a4.21 4.21 0 001.3 5.61 4.2 4.2 0 01-1.9-.52v.05a4.21 4.21 0 003.37 4.12 4.26 4.26 0 01-1.89.07 4.22 4.22 0 003.94 2.93A8.47 8.47 0 012 19.54 11.94 11.94 0 008.29 21c7.55 0 11.68-6.26 11.68-11.68 0-.18-.01-.36-.02-.53A8.34 8.34 0 0022.46 6z" />
+  </svg>
+);
+
+const InstagramIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6"
+  >
+    <path d="M7 2C4.24 2 2 4.24 2 7v10c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V7c0-2.76-2.24-5-5-5H7zm10 2a3 3 0 013 3v10a3 3 0 01-3 3H7a3 3 0 01-3-3V7a3 3 0 013-3h10zm-5 3a5 5 0 100 10 5 5 0 000-10zm0 2a3 3 0 110 6 3 3 0 010-6zm4.5-.75a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0z" />
+  </svg>
+);
 
 export default function Footer() {
   return (
     <footer className="bg-gray-900 text-gray-400 py-6 mt-20 text-center">
       <p>&copy; {new Date().getFullYear()} ErthaLoka</p>
       <div className="flex justify-center gap-4 mt-2">
-        <a href="#" className="hover:text-accent-green hover:scale-110 transition-transform"><FaFacebook /></a>
-        <a href="#" className="hover:text-accent-blue hover:scale-110 transition-transform"><FaTwitter /></a>
-        <a href="#" className="hover:text-accent-purple hover:scale-110 transition-transform"><FaInstagram /></a>
+        <a href="#" className="hover:text-accent-green hover:scale-110 transition-transform">{FacebookIcon}</a>
+        <a href="#" className="hover:text-accent-blue hover:scale-110 transition-transform">{TwitterIcon}</a>
+        <a href="#" className="hover:text-accent-purple hover:scale-110 transition-transform">{InstagramIcon}</a>
       </div>
     </footer>
   );

--- a/erthaloka-next/src/components/Hero.tsx
+++ b/erthaloka-next/src/components/Hero.tsx
@@ -34,7 +34,7 @@ export default function Hero() {
             Explore our Ecosystem
           </a>
           <a
-            href="#involved"
+            href="/signup"
             className="rounded-full bg-blue-600 hover:scale-105 transition-transform px-6 py-3 text-white font-semibold"
           >
             Join the Movement

--- a/erthaloka-next/src/components/Navbar.tsx
+++ b/erthaloka-next/src/components/Navbar.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { motion } from 'framer-motion';
+import WalletDisplay from './WalletDisplay';
+import { useAuth } from '@/context/AuthContext';
 
 const links = [
   { href: '#what', label: 'What is ErthaLoka?' },
@@ -9,6 +11,7 @@ const links = [
 ];
 
 export default function Navbar() {
+  const { user } = useAuth();
   return (
     <motion.nav
       initial={{ y: -50, opacity: 0 }}
@@ -17,7 +20,7 @@ export default function Navbar() {
       className="fixed top-0 left-0 right-0 z-50 bg-gray-900 bg-opacity-80 backdrop-blur-lg shadow-xl">
       <div className="max-w-6xl mx-auto flex items-center justify-between p-4">
         <a href="#home" className="text-3xl font-extrabold text-white">ErthaLoka</a>
-        <div className="space-x-4 hidden sm:block">
+        <div className="space-x-4 hidden sm:flex items-center">
           {links.map((link) => (
             <a
               key={link.href}
@@ -27,6 +30,7 @@ export default function Navbar() {
               {link.label}
             </a>
           ))}
+          {user && <WalletDisplay />}
         </div>
         <div className="sm:hidden">
           {/* mobile nav could be added later */}

--- a/erthaloka-next/src/components/WalletDisplay.tsx
+++ b/erthaloka-next/src/components/WalletDisplay.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot, getFirestore } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
+
+/**
+ * WalletDisplay component shows the user's current Carbon Coin balance.
+ * Firestore document structure:
+ *   users/{uid} -> { carbonCoins: number }
+ *   users/{uid}/transactions/{transactionId}
+ */
+export default function WalletDisplay() {
+  const [balance, setBalance] = useState<number>(0);
+  const auth = getAuth();
+  const db = getFirestore();
+
+  useEffect(() => {
+    const user = auth.currentUser;
+    if (!user) return;
+    const unsub = onSnapshot(doc(db, 'users', user.uid), snap => {
+      const coins = snap.exists() ? snap.data().carbonCoins || 0 : 0;
+      setBalance(coins);
+    });
+    return () => unsub();
+  }, [auth, db]);
+
+  return (
+    <div className="bg-gray-800 p-4 rounded-lg shadow-md inline-block">
+      <span className="text-4xl font-extrabold text-accent-yellow">{balance}</span>
+    </div>
+  );
+}

--- a/erthaloka-next/src/components/WhatIs.tsx
+++ b/erthaloka-next/src/components/WhatIs.tsx
@@ -1,12 +1,56 @@
 'use client';
 import { motion } from 'framer-motion';
-import { FaLeaf, FaUsers, FaGlobe, FaSeedling } from 'react-icons/fa';
+const LeafIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6 text-accent-green"
+  >
+    <path d="M12 2C8.134 2 5 5.134 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.866-3.134-7-7-7zm0 9.5A2.5 2.5 0 119.5 9 2.503 2.503 0 0112 11.5z" />
+  </svg>
+);
+
+const UsersIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6 text-accent-blue"
+  >
+    <path d="M16 14c2.21 0 4 1.79 4 4v2h-2v-2c0-1.1-.9-2-2-2h-8c-1.1 0-2 .9-2 2v2H4v-2c0-2.21 1.79-4 4-4h8zm-4-2a4 4 0 100-8 4 4 0 000 8z" />
+  </svg>
+);
+
+const GlobeIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6 text-accent-purple"
+  >
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+    <path d="M12 4a8 8 0 100 16V4z" />
+  </svg>
+);
+
+const SeedlingIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className="w-6 h-6 text-accent-yellow"
+  >
+    <path d="M12 2a7 7 0 00-7 7v2h2V9a5 5 0 015-5h2V2h-2zM7 13v5a2 2 0 002 2h6v-2H9v-5H7z" />
+    <path d="M17 13h-2v7h2v-7z" />
+  </svg>
+);
 
 const items = [
-  { icon: <FaLeaf className="text-accent-green" />, text: 'ErthaKriya – Demonstration Farms, etc.' },
-  { icon: <FaUsers className="text-accent-blue" />, text: 'ErthaVani – Awareness drives and events' },
-  { icon: <FaGlobe className="text-accent-purple" />, text: 'Erthagrama – Rural development initiatives' },
-  { icon: <FaSeedling className="text-accent-yellow" />, text: 'ErthaCANnect – Ecosystem connections' },
+  { icon: LeafIcon, text: 'ErthaKriya – Demonstration Farms, etc.' },
+  { icon: UsersIcon, text: 'ErthaVani – Awareness drives and events' },
+  { icon: GlobeIcon, text: 'Erthagrama – Rural development initiatives' },
+  { icon: SeedlingIcon, text: 'ErthaCANnect – Ecosystem connections' },
 ];
 
 export default function WhatIs() {

--- a/erthaloka-next/src/context/AuthContext.tsx
+++ b/erthaloka-next/src/context/AuthContext.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { auth } from '../firebase/config';
+
+interface AuthContextProps {
+  user: User | null;
+  loading: boolean;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  loading: true,
+  logout: async () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      setUser(firebaseUser);
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  const logout = async () => {
+    await auth.signOut();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/erthaloka-next/src/firebase/config.ts
+++ b/erthaloka-next/src/firebase/config.ts
@@ -1,0 +1,18 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export default app;


### PR DESCRIPTION
## Summary
- integrate Firebase auth context and config
- wrap the app with `AuthProvider`
- add sign up, sign in, profile and subscribe pages
- display wallet balance in navbar when signed in
- replace react-icons with inline SVGs

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848777aee308320a8d203ba4133c1ae