### PR TITLE
Add Firebase demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository contains the static website for ErthaLoka.
 
+The `erthaloka-next` directory contains a Next.js version of the site. If the
+required Firebase environment variables are not provided the app runs in a demo
+mode where authentication and data features are disabled but the UI still
+loads.
+
 ## Carbon Coin Wallet
 
 A simple Firebase based wallet system is provided.

--- a/erthaloka-next/README.md
+++ b/erthaloka-next/README.md
@@ -1,5 +1,9 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+If the required Firebase environment variables are not configured, the app will
+start in a demo mode. Pages will render but authentication and data features are
+disabled.
+
 ## Getting Started
 
 First, run the development server:

--- a/erthaloka-next/src/app/(auth)/signin/page.tsx
+++ b/erthaloka-next/src/app/(auth)/signin/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
-import { auth } from '../../firebase/config';
+import { auth, app } from '../../firebase/config';
 import Link from 'next/link';
 
 export default function SignIn() {
@@ -9,20 +9,28 @@ export default function SignIn() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
+  if (!app) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p>Authentication disabled (missing Firebase config)</p>
+      </div>
+    );
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       await signInWithEmailAndPassword(auth, email, password);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      setError((err as Error).message);
     }
   };
 
   const handleGoogle = async () => {
     try {
       await signInWithPopup(auth, new GoogleAuthProvider());
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      setError((err as Error).message);
     }
   };
 
@@ -58,7 +66,7 @@ export default function SignIn() {
           Sign in with Google
         </button>
         <p className="text-center mt-4 text-sm">
-          Don't have an account? <Link className="text-blue-400" href="/signup">Sign up</Link>
+          Don&apos;t have an account? <Link className="text-blue-400" href="/signup">Sign up</Link>
         </p>
       </form>
     </div>

--- a/erthaloka-next/src/app/(auth)/signup/page.tsx
+++ b/erthaloka-next/src/app/(auth)/signup/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
-import { auth } from '../../firebase/config';
+import { auth, app } from '../../firebase/config';
 import Link from 'next/link';
 
 export default function SignUp() {
@@ -9,12 +9,20 @@ export default function SignUp() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
+  if (!app) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p>Authentication disabled (missing Firebase config)</p>
+      </div>
+    );
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       await createUserWithEmailAndPassword(auth, email, password);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      setError((err as Error).message);
     }
   };
 

--- a/erthaloka-next/src/firebase/config.ts
+++ b/erthaloka-next/src/firebase/config.ts
@@ -1,18 +1,41 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { getAuth, Auth } from 'firebase/auth';
+import { getFirestore, Firestore } from 'firebase/firestore';
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+const missing =
+  !process.env.NEXT_PUBLIC_FIREBASE_API_KEY ||
+  !process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ||
+  !process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ||
+  !process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ||
+  !process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ||
+  !process.env.NEXT_PUBLIC_FIREBASE_APP_ID;
 
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+if (missing) {
+  console.warn('Firebase environment variables not set. Running in demo mode.');
+}
 
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+const firebaseConfig = missing
+  ? {
+      apiKey: 'demo',
+      authDomain: 'demo',
+      projectId: 'demo',
+    }
+  : {
+      apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+      authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+      storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+      messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+      appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+    };
+
+export const app = missing
+  ? undefined
+  : !getApps().length
+  ? initializeApp(firebaseConfig)
+  : getApp();
+
+export const auth = app ? getAuth(app) : ({} as unknown as Auth);
+export const db = app ? getFirestore(app) : ({} as unknown as Firestore);
+export const firebaseEnabled = !missing;
 export default app;


### PR DESCRIPTION
## Summary
- allow running Next.js app without Firebase keys
- disable auth features when Firebase isn't configured
- document demo mode in READMEs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848eb94e70c8320bf9f9fc05162d047